### PR TITLE
UserAccount 도메인 설정 및 테이블 생성

### DIFF
--- a/database/init/userAccount.sql
+++ b/database/init/userAccount.sql
@@ -1,0 +1,23 @@
+DROP TABLE IF EXISTS `user_account`;
+
+CREATE TABLE `user_account` (
+  `id` bigint NOT NULL AUTO_INCREMENT,
+  `account_id` varchar(20) NOT NULL UNIQUE,
+  `password` varchar(255) NOT NULL,
+  `name` varchar(20) NOT NULL,
+  `birthday` date NOT NULL,
+  `phone_number` varchar(20) NOT NULL,
+  `email` varchar(255) NOT NULL,
+  `role_type` varchar(20) NOT NULL,
+  `gender` char(1) NULL,
+  `nickname` varchar(20) NOT NULL,
+  `profile_image` varchar(255) NULL,
+  `profile_text` varchar(255) NULL,
+  `preference_types` varchar(255) NULL,
+  `created_at` datetime NOT NULL,
+  `created_by` varchar(20) NOT NULL,
+  `modified_at` datetime NOT NULL,
+  `modified_by` varchar(20) NOT NULL,
+  `deleted_at` datetime NULL,
+  PRIMARY KEY (`id`)
+) ENGINE=InnoDB AUTO_INCREMENT=1 DEFAULT CHARSET=utf8;

--- a/src/main/java/com/ironkim/moyeobang/domain/Account.java
+++ b/src/main/java/com/ironkim/moyeobang/domain/Account.java
@@ -1,0 +1,44 @@
+package com.ironkim.moyeobang.domain;
+
+import com.ironkim.moyeobang.domain.constant.RoleType;
+import jakarta.persistence.*;
+import lombok.*;
+import lombok.experimental.SuperBuilder;
+
+import java.time.LocalDate;
+
+@Getter
+@ToString(callSuper = true)
+@MappedSuperclass
+@SuperBuilder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public abstract class Account extends AuditingFields {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    protected Long id;
+
+    @Column(unique = true, nullable = false, length = 20)
+    protected String accountId;
+
+    @Column(nullable = false)
+    protected String password;
+
+    @Column(nullable = false, length = 20)
+    protected String name;
+
+    @Column(nullable = false)
+    protected LocalDate birthday;
+
+    @Column(nullable = false, length = 20)
+    protected String phoneNumber;
+
+    @Column(nullable = false, length = 50)
+    protected String email;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    protected RoleType roleType;
+
+}

--- a/src/main/java/com/ironkim/moyeobang/domain/AuditingFields.java
+++ b/src/main/java/com/ironkim/moyeobang/domain/AuditingFields.java
@@ -1,0 +1,45 @@
+package com.ironkim.moyeobang.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.*;
+import lombok.experimental.SuperBuilder;
+import org.springframework.data.annotation.CreatedBy;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedBy;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+import org.springframework.format.annotation.DateTimeFormat;
+
+import java.time.LocalDateTime;
+
+@Getter
+@ToString
+@EntityListeners(AuditingEntityListener.class)
+@SuperBuilder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@MappedSuperclass
+public abstract class AuditingFields {
+    @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
+    @CreatedDate
+    @Column(nullable = false, updatable = false)
+    protected LocalDateTime createdAt;
+
+    @CreatedBy
+    @Column(nullable = false, updatable = false, length = 20)
+    protected String createdBy;
+
+    @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
+    @LastModifiedDate
+    @Column(nullable = false)
+    protected LocalDateTime modifiedAt;
+
+    @LastModifiedBy
+    @Column(nullable = false, length = 20)
+    protected String modifiedBy;
+
+    @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
+    protected LocalDateTime deletedAt;
+}

--- a/src/main/java/com/ironkim/moyeobang/domain/UserAccount.java
+++ b/src/main/java/com/ironkim/moyeobang/domain/UserAccount.java
@@ -1,0 +1,39 @@
+package com.ironkim.moyeobang.domain;
+
+import com.ironkim.moyeobang.domain.constant.PreferenceType;
+import com.ironkim.moyeobang.domain.constant.RoleType;
+import com.ironkim.moyeobang.domain.converter.PreferenceTypesConverter;
+import com.ironkim.moyeobang.dto.request.UserJoinRequest;
+import jakarta.persistence.Column;
+import jakarta.persistence.Convert;
+import jakarta.persistence.Entity;
+import lombok.*;
+import lombok.experimental.SuperBuilder;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.SQLRestriction;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+
+import java.time.LocalDate;
+import java.util.LinkedHashSet;
+import java.util.Set;
+
+@Entity
+@Getter
+@ToString(callSuper = true)
+@SuperBuilder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@SQLDelete(sql = "UPDATE user_account SET deleted_at = NOW() WHERE id = ?")
+@SQLRestriction("deleted_at IS NULL")
+public class UserAccount extends Account {
+
+    @Column(length = 1)
+    private Character gender;
+    @Column(nullable = false, length = 20)
+    private String nickname;
+    private String profileImage;
+    private String profileText;
+    @Convert(converter = PreferenceTypesConverter.class)
+    private Set<PreferenceType> preferenceTypes = new LinkedHashSet<>();
+
+}

--- a/src/main/java/com/ironkim/moyeobang/domain/constant/PreferenceType.java
+++ b/src/main/java/com/ironkim/moyeobang/domain/constant/PreferenceType.java
@@ -1,0 +1,25 @@
+package com.ironkim.moyeobang.domain.constant;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum PreferenceType {
+
+    HORROR("공포"),
+    ROMANCE("로맨스"),
+    ACTION("액션"),
+    COMEDY("코미디"),
+    DRAMA("드라마"),
+    FANTASY("판타지"),
+    THRILLER("스릴러"),
+    MYSTERY("미스터리"),
+    CRIME("범죄"),
+    ADVENTURE("모험"),
+    SCIENCE_FICTION("SF"),
+    ETC("기타")
+    ;
+
+    private final String name;
+}

--- a/src/main/java/com/ironkim/moyeobang/domain/constant/RoleType.java
+++ b/src/main/java/com/ironkim/moyeobang/domain/constant/RoleType.java
@@ -1,0 +1,16 @@
+package com.ironkim.moyeobang.domain.constant;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum RoleType {
+    ADMIN("ROLE_ADMIN", "관리자"),
+    SELLER("ROLE_SELLER", "판매자"),
+    USER("ROLE_USER", "사용자")
+    ;
+
+    private final String name;
+    private final String description;
+}

--- a/src/main/java/com/ironkim/moyeobang/domain/converter/PreferenceTypesConverter.java
+++ b/src/main/java/com/ironkim/moyeobang/domain/converter/PreferenceTypesConverter.java
@@ -1,0 +1,25 @@
+package com.ironkim.moyeobang.domain.converter;
+
+import com.ironkim.moyeobang.domain.constant.PreferenceType;
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
+
+import java.util.Arrays;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+@Converter
+public class PreferenceTypesConverter implements AttributeConverter<Set<PreferenceType>, String> {
+
+    private static final String DELIMITER = ",";
+
+    @Override
+    public String convertToDatabaseColumn(Set<PreferenceType> attribute) {
+        return attribute.stream().map(PreferenceType::name).sorted().collect(Collectors.joining(DELIMITER));
+    }
+
+    @Override
+    public Set<PreferenceType> convertToEntityAttribute(String dbData) {
+        return Arrays.stream(dbData.split(DELIMITER)).map(PreferenceType::valueOf).collect(Collectors.toSet());
+    }
+}


### PR DESCRIPTION
다른 엔티티와 공통 필드를 AuditingFields로 묶고
사용자 계정과 판매자 계정의 공통 필드를 Account로 묶었다.

RoleType으로 관리자, 판매자, 사용자 Role을 나눴다.

PreferenceType은 Converter를 거처 DB에 쉼표로 구분지어 한줄 텍스트로 넣고 꺼낼때는 쉼표로 구분지어 Set자료형으로 꺼내며 순서가 보장되도록 LinkedHashSet를 선언해주었다.