### PR TITLE
GlobalControllerAdvice와 MoyeobangApplicationException, ErrorCode 추가

### DIFF
--- a/src/main/java/com/ironkim/moyeobang/exception/ErrorCode.java
+++ b/src/main/java/com/ironkim/moyeobang/exception/ErrorCode.java
@@ -1,0 +1,21 @@
+package com.ironkim.moyeobang.exception;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum ErrorCode {
+    DUPLICATED_ACCOUNT_ID(HttpStatus.CONFLICT, "AccountId is duplicated"),
+    ACCOUNT_NOT_FOUND(HttpStatus.NOT_FOUND, "Account not founded"),
+    INVALID_PASSWORD(HttpStatus.UNAUTHORIZED, "Password is invalid"),
+    INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "Token is invalid"),
+    POST_NOT_FOUND(HttpStatus.NOT_FOUND, "Post not founded"),
+    INVALID_PERMISSION(HttpStatus.UNAUTHORIZED, "Permission is invalid"),
+    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "Internal server error"),
+    ;
+
+    private final HttpStatus status;
+    private final String message;
+}

--- a/src/main/java/com/ironkim/moyeobang/exception/GlobalControllerAdvice.java
+++ b/src/main/java/com/ironkim/moyeobang/exception/GlobalControllerAdvice.java
@@ -1,0 +1,26 @@
+package com.ironkim.moyeobang.exception;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@Slf4j
+@RestControllerAdvice
+public class GlobalControllerAdvice {
+
+    @ExceptionHandler(MoyeobangApplicationException.class)
+    public ResponseEntity<?> applicationHandler(MoyeobangApplicationException e) {
+        log.error("Error occurs {}", e.toString());
+        return ResponseEntity.status(e.getErrorCode().getStatus())
+                .body(e.getErrorCode().name());
+    }
+
+    @ExceptionHandler(RuntimeException.class)
+    public ResponseEntity<?> applicationHandler(RuntimeException e) {
+        log.error("Error occurs {}", e.toString());
+        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                .body(ErrorCode.INTERNAL_SERVER_ERROR.name());
+    }
+}

--- a/src/main/java/com/ironkim/moyeobang/exception/MoyeobangApplicationException.java
+++ b/src/main/java/com/ironkim/moyeobang/exception/MoyeobangApplicationException.java
@@ -1,0 +1,26 @@
+package com.ironkim.moyeobang.exception;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class MoyeobangApplicationException extends RuntimeException {
+
+    private ErrorCode errorCode;
+    private String message;
+
+    public MoyeobangApplicationException(ErrorCode errorCode) {
+        this.errorCode = errorCode;
+        this.message = null;
+    }
+
+    @Override
+    public String getMessage() {
+        if(message == null) {
+            return errorCode.getMessage();
+        }
+
+        return String.format("%s. %s", errorCode.getMessage(), message);
+    }
+}


### PR DESCRIPTION
MoyeobangApplicationException가 Exception 핸들러 역할을 하며 에러는 ErrorCode로 정의하며 GlobalControllerAdvice로 에러코드를 프론트로 전달한다. 정의 되어있지 않는 에러코드는 INTERNAL_SERVER_ERROR로 응답함